### PR TITLE
deploy to prod apps when creating a new release

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,0 +1,16 @@
+name: Deploy Prod
+on:
+  release:
+    types: [published]
+
+
+jobs:
+  trigger_deploy:
+    name: Trigger DO Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Webhook
+        uses: joelwmale/webhook-action@master
+        with:
+          url: ${{ secrets.WEBHOOK_URL }}
+          headers: '{"Authorization": "Bearer ${{ secrets.DO_TOKEN }}"}'


### PR DESCRIPTION
When we create a new release from the github UI we should deploy it to
Digital Ocean where we host our apps